### PR TITLE
Fix sedit command, mismatch of stall name for reviews

### DIFF
--- a/src/main/java/foodwhere/logic/commands/RAddCommand.java
+++ b/src/main/java/foodwhere/logic/commands/RAddCommand.java
@@ -76,7 +76,7 @@ public class RAddCommand extends Command {
         if (model.hasReview(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_REVIEW);
         }
-
+        stall.addReview(toAdd);
         model.addReview(toAdd);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));

--- a/src/main/java/foodwhere/logic/commands/SEditCommand.java
+++ b/src/main/java/foodwhere/logic/commands/SEditCommand.java
@@ -80,7 +80,7 @@ public class SEditCommand extends Command {
             assert (reviewsToEdit.length == editedReviews.length);
 
             for (int i = 0; i < editedReviews.length; i++) {
-                model.setReview(reviewsToEdit[i],editedReviews[i]);
+                model.setReview(reviewsToEdit[i], editedReviews[i]);
             }
             model.updateFilteredReviewList(PREDICATE_SHOW_ALL_REVIEWS);
         }
@@ -107,11 +107,15 @@ public class SEditCommand extends Command {
         Set<Review> updatedReviews = new HashSet<>();
         if (updatedName.equals(stallToEdit.getName())) {
             updatedReviews = reviewsToUpdate;
-        }
-        else {
+        } else {
             if (!reviewsToUpdate.isEmpty()) {
                 for (Review review : reviewsToUpdate) {
-                    Review updatedReview = new Review(updatedName, review.getDate(), review.getContent(), review.getRating(), review.getTags());
+                    Review updatedReview = new Review(
+                            updatedName,
+                            review.getDate(),
+                            review.getContent(),
+                            review.getRating(),
+                            review.getTags());
                     updatedReviews.add(updatedReview);
                 }
             }

--- a/src/main/java/foodwhere/model/stall/Stall.java
+++ b/src/main/java/foodwhere/model/stall/Stall.java
@@ -9,7 +9,6 @@ import java.util.Set;
 
 import foodwhere.model.commons.Name;
 import foodwhere.model.commons.Tag;
-import foodwhere.model.review.Rating;
 import foodwhere.model.review.Review;
 
 /**
@@ -73,6 +72,10 @@ public class Stall {
         return Collections.unmodifiableSet(reviews);
     }
 
+    /**
+     * Adds a review to the review set.
+     * The review must not already exist in the review set.
+     */
     public void addReview(Review review) {
         reviews.add(review);
     }

--- a/src/main/java/foodwhere/model/stall/Stall.java
+++ b/src/main/java/foodwhere/model/stall/Stall.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 import foodwhere.model.commons.Name;
 import foodwhere.model.commons.Tag;
+import foodwhere.model.review.Rating;
 import foodwhere.model.review.Review;
 
 /**
@@ -70,6 +71,10 @@ public class Stall {
      */
     public Set<Review> getReviews() {
         return Collections.unmodifiableSet(reviews);
+    }
+
+    public void addReview(Review review) {
+        reviews.add(review);
     }
 
     /**


### PR DESCRIPTION
Resolve #199 

When the sedit command changes the stall name, the stall names in the reviews associated with the stalls are not modified in both the review list in model and stall. 

The sedit now updates the stall name of the associated reviews in model and stall.

Updating associated reviews in model:
![image](https://user-images.githubusercontent.com/6292956/196687401-b1b7feb9-1b7c-42e2-ab13-7e81dcb22834.png)

Updating associated reviews in stall:
![image](https://user-images.githubusercontent.com/6292956/196687728-87459163-1543-403d-9d57-7a3618bb117b.png)

