### PR TITLE
Move StallBuilder into model.stall and add Review to SEditCommand

### DIFF
--- a/src/main/java/foodwhere/logic/commands/SEditCommand.java
+++ b/src/main/java/foodwhere/logic/commands/SEditCommand.java
@@ -17,6 +17,7 @@ import foodwhere.logic.parser.CliSyntax;
 import foodwhere.model.Model;
 import foodwhere.model.commons.Name;
 import foodwhere.model.commons.Tag;
+import foodwhere.model.review.Review;
 import foodwhere.model.stall.Address;
 import foodwhere.model.stall.Stall;
 
@@ -116,6 +117,7 @@ public class SEditCommand extends Command {
         private Name name;
         private Address address;
         private Set<Tag> tags;
+        private Set<Review> reviews;
 
         public EditStallDescriptor() {}
 
@@ -127,6 +129,7 @@ public class SEditCommand extends Command {
             setName(toCopy.name);
             setAddress(toCopy.address);
             setTags(toCopy.tags);
+            setReviews(toCopy.reviews);
         }
 
         /**
@@ -167,6 +170,23 @@ public class SEditCommand extends Command {
          */
         public Optional<Set<Tag>> getTags() {
             return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+        }
+
+        /**
+         * Sets {@code reviews} to this object's {@code reviews}.
+         * A defensive copy of {@code reviews} is used internally.
+         */
+        public void setReviews(Set<Review> reviews) {
+            this.reviews = (reviews != null) ? new HashSet<>(reviews) : null;
+        }
+
+        /**
+         * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException}
+         * if modification is attempted.
+         * Returns {@code Optional#empty()} if {@code tags} is null.
+         */
+        public Optional<Set<Review>> getReviews() {
+            return (reviews != null) ? Optional.of(Collections.unmodifiableSet(reviews)) : Optional.empty();
         }
 
         @Override

--- a/src/main/java/foodwhere/model/stall/StallBuilder.java
+++ b/src/main/java/foodwhere/model/stall/StallBuilder.java
@@ -1,14 +1,16 @@
-package foodwhere.testutil;
+package foodwhere.model.stall;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import foodwhere.model.commons.Name;
 import foodwhere.model.commons.Tag;
 import foodwhere.model.review.Review;
-import foodwhere.model.stall.Address;
-import foodwhere.model.stall.Stall;
+import foodwhere.model.review.exceptions.ReviewNotFoundException;
 import foodwhere.model.util.SampleDataUtil;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * A utility class to help with building Stall objects.
@@ -21,7 +23,7 @@ public class StallBuilder {
     private Name name;
     private Address address;
     private Set<Tag> tags;
-    private Set<Review> reviews;
+    private HashSet<Review> reviews;
 
     /**
      * Creates a {@code StallBuilder} with the default details.
@@ -44,7 +46,7 @@ public class StallBuilder {
     }
 
     /**
-     * Sets the {@code Name} of the {@code Stall} that we are building.
+     * Sets the {@code name} of the {@code Stall} that we are building.
      */
     public StallBuilder withName(String name) {
         this.name = new Name(name);
@@ -60,7 +62,7 @@ public class StallBuilder {
     }
 
     /**
-     * Sets the {@code Address} of the {@code Stall} that we are building.
+     * Sets the {@code address} of the {@code Stall} that we are building.
      */
     public StallBuilder withAddress(String address) {
         this.address = new Address(address);
@@ -68,15 +70,43 @@ public class StallBuilder {
     }
 
     /**
-     * Sets the {@code Review} of the {@code Stall} that we are building.
+     * Sets the {@code reviews} of the {@code Stall} that we are building.
      */
-    public StallBuilder withReview(Review ... reviews) {
-        this.reviews = SampleDataUtil.getReviewSet(reviews);
+    public StallBuilder withReviews(Review ... reviews) {
+        requireNonNull(reviews);
+        for (Review review : reviews) {
+            requireNonNull(review);
+        }
+        this.reviews = new HashSet<>(List.of(reviews));
         return this;
     }
 
+    /**
+     * Adds a review to the {@code Stall} that we are building.
+     */
+    public StallBuilder addReview(Review review) {
+        requireNonNull(review);
+        this.reviews.add(review);
+        return this;
+    }
+
+    /**
+     * Removes a review from the {@code Stall} that we are building.
+     */
+    public StallBuilder removeReview(Review review) {
+        requireNonNull(review);
+        if (!this.reviews.contains(review)) {
+            throw new ReviewNotFoundException();
+        }
+        this.reviews.remove(review);
+        return this;
+    }
+
+    /**
+     * Builds a stall.
+     * @return Stall with the stored data.
+     */
     public Stall build() {
         return new Stall(name, address, tags, reviews);
     }
-
 }

--- a/src/test/java/foodwhere/logic/LogicManagerTest.java
+++ b/src/test/java/foodwhere/logic/LogicManagerTest.java
@@ -24,10 +24,10 @@ import foodwhere.model.ModelManager;
 import foodwhere.model.ReadOnlyAddressBook;
 import foodwhere.model.UserPrefs;
 import foodwhere.model.stall.Stall;
+import foodwhere.model.stall.StallBuilder;
 import foodwhere.storage.JsonAddressBookStorage;
 import foodwhere.storage.JsonUserPrefsStorage;
 import foodwhere.storage.StorageManager;
-import foodwhere.testutil.StallBuilder;
 
 public class LogicManagerTest {
     private static final IOException DUMMY_IO_EXCEPTION = new IOException("dummy exception");

--- a/src/test/java/foodwhere/logic/commands/SAddCommandIntegrationTest.java
+++ b/src/test/java/foodwhere/logic/commands/SAddCommandIntegrationTest.java
@@ -10,7 +10,7 @@ import foodwhere.model.Model;
 import foodwhere.model.ModelManager;
 import foodwhere.model.UserPrefs;
 import foodwhere.model.stall.Stall;
-import foodwhere.testutil.StallBuilder;
+import foodwhere.model.stall.StallBuilder;
 import foodwhere.testutil.TypicalStalls;
 
 /**

--- a/src/test/java/foodwhere/logic/commands/SAddCommandTest.java
+++ b/src/test/java/foodwhere/logic/commands/SAddCommandTest.java
@@ -21,7 +21,7 @@ import foodwhere.model.ReadOnlyAddressBook;
 import foodwhere.model.ReadOnlyUserPrefs;
 import foodwhere.model.review.Review;
 import foodwhere.model.stall.Stall;
-import foodwhere.testutil.StallBuilder;
+import foodwhere.model.stall.StallBuilder;
 import javafx.collections.ObservableList;
 
 public class SAddCommandTest {

--- a/src/test/java/foodwhere/logic/commands/SEditCommandTest.java
+++ b/src/test/java/foodwhere/logic/commands/SEditCommandTest.java
@@ -13,8 +13,8 @@ import foodwhere.model.Model;
 import foodwhere.model.ModelManager;
 import foodwhere.model.UserPrefs;
 import foodwhere.model.stall.Stall;
+import foodwhere.model.stall.StallBuilder;
 import foodwhere.testutil.EditStallDescriptorBuilder;
-import foodwhere.testutil.StallBuilder;
 import foodwhere.testutil.TypicalIndexes;
 import foodwhere.testutil.TypicalStalls;
 

--- a/src/test/java/foodwhere/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/foodwhere/logic/parser/AddressBookParserTest.java
@@ -26,9 +26,9 @@ import foodwhere.logic.parser.exceptions.ParseException;
 import foodwhere.model.review.Review;
 import foodwhere.model.stall.NameContainsKeywordsPredicate;
 import foodwhere.model.stall.Stall;
+import foodwhere.model.stall.StallBuilder;
 import foodwhere.testutil.EditStallDescriptorBuilder;
 import foodwhere.testutil.ReviewBuilder;
-import foodwhere.testutil.StallBuilder;
 import foodwhere.testutil.StallUtil;
 import foodwhere.testutil.TypicalIndexes;
 

--- a/src/test/java/foodwhere/logic/parser/SAddCommandParserTest.java
+++ b/src/test/java/foodwhere/logic/parser/SAddCommandParserTest.java
@@ -26,7 +26,7 @@ import foodwhere.model.commons.Name;
 import foodwhere.model.commons.Tag;
 import foodwhere.model.stall.Address;
 import foodwhere.model.stall.Stall;
-import foodwhere.testutil.StallBuilder;
+import foodwhere.model.stall.StallBuilder;
 import foodwhere.testutil.TypicalStalls;
 
 public class SAddCommandParserTest {

--- a/src/test/java/foodwhere/model/AddressBookTest.java
+++ b/src/test/java/foodwhere/model/AddressBookTest.java
@@ -18,8 +18,8 @@ import org.junit.jupiter.api.Test;
 
 import foodwhere.model.review.Review;
 import foodwhere.model.stall.Stall;
+import foodwhere.model.stall.StallBuilder;
 import foodwhere.model.stall.exceptions.DuplicateStallException;
-import foodwhere.testutil.StallBuilder;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 

--- a/src/test/java/foodwhere/model/stall/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/foodwhere/model/stall/NameContainsKeywordsPredicateTest.java
@@ -9,8 +9,6 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import foodwhere.testutil.StallBuilder;
-
 public class NameContainsKeywordsPredicateTest {
 
     @Test

--- a/src/test/java/foodwhere/model/stall/StallBuilderTest.java
+++ b/src/test/java/foodwhere/model/stall/StallBuilderTest.java
@@ -1,0 +1,36 @@
+package foodwhere.model.stall;
+
+import static foodwhere.testutil.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import foodwhere.model.review.exceptions.ReviewNotFoundException;
+import org.junit.jupiter.api.Test;
+
+import foodwhere.logic.commands.CommandTestUtil;
+import foodwhere.testutil.TypicalReviews;
+import foodwhere.testutil.TypicalStalls;
+
+
+import foodwhere.logic.commands.CommandTestUtil;
+import foodwhere.model.review.Review;
+import foodwhere.testutil.TypicalReviews;
+import foodwhere.testutil.TypicalStalls;
+
+public class StallBuilderTest {
+
+    @Test
+    public void addReview_normalBehavior_success() {
+        StallBuilder stall = new StallBuilder(TypicalStalls.ALICE);
+        stall.addReview(TypicalReviews.BOB);
+        stall.removeReview(TypicalReviews.BOB);
+        assertEquals(TypicalStalls.ALICE, stall.build());
+    }
+
+    @Test
+    public void removeReview_removeNotPresent_throwsError() {
+        StallBuilder stall = new StallBuilder(TypicalStalls.ALICE);
+        assertThrows(ReviewNotFoundException.class, () -> stall.removeReview(TypicalReviews.BOB));
+    }
+}

--- a/src/test/java/foodwhere/model/stall/StallTest.java
+++ b/src/test/java/foodwhere/model/stall/StallTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
 import foodwhere.logic.commands.CommandTestUtil;
-import foodwhere.testutil.StallBuilder;
 import foodwhere.testutil.TypicalReviews;
 import foodwhere.testutil.TypicalStalls;
 
@@ -31,7 +30,7 @@ public class StallTest {
         Stall editedAlice = new StallBuilder(TypicalStalls.ALICE)
                 .withAddress(CommandTestUtil.VALID_ADDRESS_BOB)
                 .withTags(CommandTestUtil.VALID_TAG_HUSBAND)
-                .withReview(TypicalReviews.BOB)
+                .withReviews(TypicalReviews.BOB)
                 .build();
         assertTrue(TypicalStalls.ALICE.isSameStall(editedAlice));
 
@@ -81,8 +80,8 @@ public class StallTest {
         assertFalse(TypicalStalls.ALICE.equals(editedAlice));
 
         // different reviews -> returns false
-        Stall alice = new StallBuilder(TypicalStalls.ALICE).withReview(TypicalReviews.ALICE).build();
-        editedAlice = new StallBuilder(TypicalStalls.ALICE).withReview(TypicalReviews.BOB).build();
+        Stall alice = new StallBuilder(TypicalStalls.ALICE).withReviews(TypicalReviews.ALICE).build();
+        editedAlice = new StallBuilder(TypicalStalls.ALICE).withReviews(TypicalReviews.BOB).build();
         assertFalse(alice.equals(editedAlice));
     }
 }

--- a/src/test/java/foodwhere/model/stall/UniqueStallListTest.java
+++ b/src/test/java/foodwhere/model/stall/UniqueStallListTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import foodwhere.logic.commands.CommandTestUtil;
 import foodwhere.model.stall.exceptions.DuplicateStallException;
 import foodwhere.model.stall.exceptions.StallNotFoundException;
-import foodwhere.testutil.StallBuilder;
 import foodwhere.testutil.TypicalStalls;
 
 public class UniqueStallListTest {

--- a/src/test/java/foodwhere/testutil/TypicalStalls.java
+++ b/src/test/java/foodwhere/testutil/TypicalStalls.java
@@ -14,7 +14,7 @@ import java.util.List;
 import foodwhere.model.AddressBook;
 import foodwhere.model.review.Review;
 import foodwhere.model.stall.Stall;
-
+import foodwhere.model.stall.StallBuilder;
 
 /**
  * A utility class containing a list of {@code Stall} objects to be used in tests.


### PR DESCRIPTION
Resolve #203.

Instead of the original plan, StallBuilder is moved into model.stall to prepare for the bugfix.

The main reason for it is that EditStallDescriptor stores an edit to a Stall which takes in the Stall later to edit, while StallBuilder needs the Stall upfront to edit.

The adding of Review to SEditCommand is also conducted to avoid future bugs when doing the bugfix.