### PR TITLE
Make Reviews follow new Stall name on rename

### DIFF
--- a/src/main/java/foodwhere/logic/commands/SEditCommand.java
+++ b/src/main/java/foodwhere/logic/commands/SEditCommand.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import foodwhere.commons.core.Messages;
 import foodwhere.commons.core.index.Index;
@@ -18,6 +19,7 @@ import foodwhere.model.Model;
 import foodwhere.model.commons.Name;
 import foodwhere.model.commons.Tag;
 import foodwhere.model.review.Review;
+import foodwhere.model.review.ReviewBuilder;
 import foodwhere.model.stall.Address;
 import foodwhere.model.stall.Stall;
 
@@ -87,7 +89,11 @@ public class SEditCommand extends Command {
         Name updatedName = editStallDescriptor.getName().orElse(stallToEdit.getName());
         Address updatedAddress = editStallDescriptor.getAddress().orElse(stallToEdit.getAddress());
         Set<Tag> updatedTags = editStallDescriptor.getTags().orElse(stallToEdit.getTags());
-        Set<Review> updatedReviews = editStallDescriptor.getReviews().orElse(stallToEdit.getReviews());
+        Set<Review> updatedReviews = editStallDescriptor.getReviews()
+                .orElse(stallToEdit.getReviews())
+                .stream()
+                .map(review -> new ReviewBuilder(review).withName(updatedName.fullName).build())
+                .collect(Collectors.toSet());
         return new Stall(updatedName, updatedAddress, updatedTags, updatedReviews);
     }
 

--- a/src/main/java/foodwhere/model/review/ReviewBuilder.java
+++ b/src/main/java/foodwhere/model/review/ReviewBuilder.java
@@ -1,14 +1,10 @@
-package foodwhere.testutil;
+package foodwhere.model.review;
 
 import java.util.HashSet;
 import java.util.Set;
 
 import foodwhere.model.commons.Name;
 import foodwhere.model.commons.Tag;
-import foodwhere.model.review.Content;
-import foodwhere.model.review.Date;
-import foodwhere.model.review.Rating;
-import foodwhere.model.review.Review;
 import foodwhere.model.util.SampleDataUtil;
 
 /**
@@ -16,9 +12,9 @@ import foodwhere.model.util.SampleDataUtil;
  */
 public class ReviewBuilder {
 
-    public static final String DEFAULT_NAME = "Amy Bee";
-    public static final String DEFAULT_DATE = "1/1/2020";
-    public static final String DEFAULT_CONTENT = "123, Jurong West Ave 6, #08-111";
+    public static final String DEFAULT_NAME = "Untitled Review";
+    public static final String DEFAULT_DATE = "1/1/1970";
+    public static final String DEFAULT_CONTENT = "No comment.";
     public static final Integer DEFAULT_RATING = 3;
 
     private Name name;

--- a/src/main/java/foodwhere/model/stall/StallBuilder.java
+++ b/src/main/java/foodwhere/model/stall/StallBuilder.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import foodwhere.model.commons.Name;
 import foodwhere.model.commons.Tag;
 import foodwhere.model.review.Review;
+import foodwhere.model.review.ReviewBuilder;
 import foodwhere.model.review.exceptions.ReviewNotFoundException;
 import foodwhere.model.util.SampleDataUtil;
 
@@ -17,8 +18,8 @@ import foodwhere.model.util.SampleDataUtil;
  */
 public class StallBuilder {
 
-    public static final String DEFAULT_NAME = "Amy Bee";
-    public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
+    public static final String DEFAULT_NAME = "Unnamed Stall";
+    public static final String DEFAULT_ADDRESS = "Unknown Location";
 
     private Name name;
     private Address address;
@@ -107,6 +108,12 @@ public class StallBuilder {
      * @return Stall with the stored data.
      */
     public Stall build() {
-        return new Stall(name, address, tags, reviews);
+        HashSet<Review> namedReviews = new HashSet<>();
+        for (Review review : reviews) {
+            Review namedReview = new ReviewBuilder(review)
+                    .withName(name.fullName).build();
+            namedReviews.add(namedReview);
+        }
+        return new Stall(name, address, tags, namedReviews);
     }
 }

--- a/src/test/java/foodwhere/logic/commands/RAddCommandTest.java
+++ b/src/test/java/foodwhere/logic/commands/RAddCommandTest.java
@@ -13,8 +13,8 @@ import foodwhere.model.Model;
 import foodwhere.model.ModelManager;
 import foodwhere.model.UserPrefs;
 import foodwhere.model.review.Review;
+import foodwhere.model.review.ReviewBuilder;
 import foodwhere.model.stall.Stall;
-import foodwhere.testutil.ReviewBuilder;
 import foodwhere.testutil.TypicalIndexes;
 import foodwhere.testutil.TypicalStalls;
 

--- a/src/test/java/foodwhere/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/foodwhere/logic/parser/AddressBookParserTest.java
@@ -24,11 +24,11 @@ import foodwhere.logic.commands.SFindCommand;
 import foodwhere.logic.commands.SListCommand;
 import foodwhere.logic.parser.exceptions.ParseException;
 import foodwhere.model.review.Review;
+import foodwhere.model.review.ReviewBuilder;
 import foodwhere.model.stall.NameContainsKeywordsPredicate;
 import foodwhere.model.stall.Stall;
 import foodwhere.model.stall.StallBuilder;
 import foodwhere.testutil.EditStallDescriptorBuilder;
-import foodwhere.testutil.ReviewBuilder;
 import foodwhere.testutil.StallUtil;
 import foodwhere.testutil.TypicalIndexes;
 

--- a/src/test/java/foodwhere/logic/parser/RAddCommandParserTest.java
+++ b/src/test/java/foodwhere/logic/parser/RAddCommandParserTest.java
@@ -28,7 +28,7 @@ import foodwhere.logic.commands.RAddCommand;
 import foodwhere.model.commons.Tag;
 import foodwhere.model.review.Date;
 import foodwhere.model.review.Review;
-import foodwhere.testutil.ReviewBuilder;
+import foodwhere.model.review.ReviewBuilder;
 import foodwhere.testutil.TypicalReviews;
 
 public class RAddCommandParserTest {

--- a/src/test/java/foodwhere/model/AddressBookTest.java
+++ b/src/test/java/foodwhere/model/AddressBookTest.java
@@ -18,10 +18,10 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import foodwhere.model.review.Review;
+import foodwhere.model.review.ReviewBuilder;
 import foodwhere.model.stall.Stall;
 import foodwhere.model.stall.StallBuilder;
 import foodwhere.model.stall.exceptions.DuplicateStallException;
-import foodwhere.testutil.ReviewBuilder;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 

--- a/src/test/java/foodwhere/model/review/ReviewTest.java
+++ b/src/test/java/foodwhere/model/review/ReviewTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
 import foodwhere.logic.commands.CommandTestUtil;
-import foodwhere.testutil.ReviewBuilder;
 import foodwhere.testutil.TypicalReviews;
 
 public class ReviewTest {

--- a/src/test/java/foodwhere/model/review/UniqueReviewListTest.java
+++ b/src/test/java/foodwhere/model/review/UniqueReviewListTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import foodwhere.logic.commands.CommandTestUtil;
 import foodwhere.model.review.exceptions.DuplicateReviewException;
 import foodwhere.model.review.exceptions.ReviewNotFoundException;
-import foodwhere.testutil.ReviewBuilder;
 import foodwhere.testutil.TypicalReviews;
 
 public class UniqueReviewListTest {

--- a/src/test/java/foodwhere/model/stall/StallBuilderTest.java
+++ b/src/test/java/foodwhere/model/stall/StallBuilderTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
+import foodwhere.model.review.Review;
 import foodwhere.model.review.exceptions.ReviewNotFoundException;
 import foodwhere.testutil.TypicalReviews;
 import foodwhere.testutil.TypicalStalls;
@@ -23,5 +24,16 @@ public class StallBuilderTest {
     public void removeReview_removeNotPresent_throwsError() {
         StallBuilder stall = new StallBuilder(TypicalStalls.ALICE);
         assertThrows(ReviewNotFoundException.class, () -> stall.removeReview(TypicalReviews.BOB));
+    }
+
+    @Test
+    public void withName_withReview_renamesReviews() {
+        String newName = "Another Food Place";
+        Stall stall = new StallBuilder(TypicalStalls.ALICE)
+                .addReview(TypicalReviews.ALICE)
+                .withName(newName).build();
+        for (Review review : stall.getReviews()) {
+            assertEquals(newName, review.getName().fullName);
+        }
     }
 }

--- a/src/test/java/foodwhere/testutil/TypicalReviews.java
+++ b/src/test/java/foodwhere/testutil/TypicalReviews.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import foodwhere.model.review.Review;
+import foodwhere.model.review.ReviewBuilder;
 
 /**
  * A utility class containing a list of {@code Review} objects to be used in tests.


### PR DESCRIPTION
Currently, when a Stall is renamed, the corresponding review do not get renamed to match the name of the stall. This behavior is considered to be a bug.

Let's
1. Update StallBuilder to rename the reviews when building
2. Update SEditCommand::createEditedStall to rename the reviews when building