### PR TITLE
Relax Stall notion of equality to include Address

### DIFF
--- a/src/main/java/foodwhere/logic/commands/RAddCommand.java
+++ b/src/main/java/foodwhere/logic/commands/RAddCommand.java
@@ -16,6 +16,7 @@ import foodwhere.model.review.Content;
 import foodwhere.model.review.Date;
 import foodwhere.model.review.Rating;
 import foodwhere.model.review.Review;
+import foodwhere.model.stall.Address;
 import foodwhere.model.stall.Stall;
 
 /**
@@ -71,14 +72,15 @@ public class RAddCommand extends Command {
         Stall stall = lastShownList.get(stallIndex.getZeroBased());
 
         Name name = stall.getName();
+        Address address = stall.getAddress();
 
-        Review toAdd = new Review(name, date, content, rating, tagList);
+        Review toAdd = new Review(name, address, date, content, rating, tagList);
 
         if (model.hasReview(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_REVIEW);
         }
 
-        model.addReview(toAdd);
+        model.addReviewToStall(toAdd, stall);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }

--- a/src/main/java/foodwhere/logic/commands/REditCommand.java
+++ b/src/main/java/foodwhere/logic/commands/REditCommand.java
@@ -21,6 +21,7 @@ import foodwhere.model.review.Content;
 import foodwhere.model.review.Date;
 import foodwhere.model.review.Rating;
 import foodwhere.model.review.Review;
+import foodwhere.model.stall.Address;
 
 /**
  * Edits the details of an existing review in the address book.
@@ -87,12 +88,13 @@ public class REditCommand extends Command {
         assert reviewToEdit != null;
 
         Name name = reviewToEdit.getName();
+        Address address = reviewToEdit.getAddress();
         Date updatedDate = editReviewDescriptor.getDate().orElse(reviewToEdit.getDate());
         Content updatedContent = editReviewDescriptor.getContent().orElse(reviewToEdit.getContent());
         Rating updatedRating = editReviewDescriptor.getRating().orElse(reviewToEdit.getRating());
         Set<Tag> updatedTags = editReviewDescriptor.getTags().orElse(reviewToEdit.getTags());
 
-        return new Review(name, updatedDate, updatedContent, updatedRating, updatedTags);
+        return new Review(name, address, updatedDate, updatedContent, updatedRating, updatedTags);
     }
 
     @Override

--- a/src/main/java/foodwhere/logic/commands/SEditCommand.java
+++ b/src/main/java/foodwhere/logic/commands/SEditCommand.java
@@ -92,7 +92,10 @@ public class SEditCommand extends Command {
         Set<Review> updatedReviews = editStallDescriptor.getReviews()
                 .orElse(stallToEdit.getReviews())
                 .stream()
-                .map(review -> new ReviewBuilder(review).withName(updatedName.fullName).build())
+                .map(review -> new ReviewBuilder(review)
+                        .withName(updatedName.fullName)
+                        .withAddress(updatedAddress.value)
+                        .build())
                 .collect(Collectors.toSet());
         return new Stall(updatedName, updatedAddress, updatedTags, updatedReviews);
     }

--- a/src/main/java/foodwhere/model/AddressBook.java
+++ b/src/main/java/foodwhere/model/AddressBook.java
@@ -78,7 +78,9 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     private Stall getStallOfReview(Review review) throws StallNotFoundException {
         for (Stall stall : stalls) {
-            if (stall.getName().equals(review.getName())) {
+            boolean isMatchingName = stall.getName().equals(review.getName());
+            boolean isMatchingAddress = stall.getAddress().equals(review.getAddress());
+            if (isMatchingName && isMatchingAddress) {
                 return stall;
             }
         }

--- a/src/main/java/foodwhere/model/AddressBook.java
+++ b/src/main/java/foodwhere/model/AddressBook.java
@@ -174,6 +174,18 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Adds a review to a stall in the address book.
+     * The review must not already exist in the address book.
+     * The stall must exist in the address book.
+     */
+    public void addReviewToStall(Review review, Stall stall) {
+        requireNonNull(review);
+        Stall newStall = new StallBuilder(stall)
+                .addReview(review).build();
+        setStall(stall, newStall);
+    }
+
+    /**
      * Replaces the given review {@code target} in the list with {@code editedReview}.
      * {@code target} must exist in the address book.
      * The review identity of {@code editedReview} must not be the same as another existing review in the address book.

--- a/src/main/java/foodwhere/model/Model.java
+++ b/src/main/java/foodwhere/model/Model.java
@@ -104,6 +104,12 @@ public interface Model {
     void addReview(Review review);
 
     /**
+     * Adds the given review to the stall.
+     * {@code review} must not already exist in the address book.
+     */
+    void addReviewToStall(Review review, Stall stall);
+
+    /**
      * Replaces the given review {@code target} with {@code editedReview}.
      * {@code target} must exist in the address book.
      * The review identity of {@code editedReview} must not be the same as another existing review in the address book.

--- a/src/main/java/foodwhere/model/ModelManager.java
+++ b/src/main/java/foodwhere/model/ModelManager.java
@@ -139,6 +139,13 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void addReviewToStall(Review review, Stall stall) {
+        addressBook.addReviewToStall(review, stall);
+        updateFilteredReviewList(PREDICATE_SHOW_ALL_REVIEWS);
+        updateFilteredStallList(PREDICATE_SHOW_ALL_STALLS);
+    }
+
+    @Override
     public void setReview(Review target, Review editedStall) {
         requireAllNonNull(target, editedStall);
 

--- a/src/main/java/foodwhere/model/review/Review.java
+++ b/src/main/java/foodwhere/model/review/Review.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 import foodwhere.model.commons.Name;
 import foodwhere.model.commons.Tag;
+import foodwhere.model.stall.Address;
 
 /**
  * Represents a Review in the address book.
@@ -19,6 +20,8 @@ public class Review {
     // Identity fields
     private final Name name;
 
+    private final Address address;
+
     // Data fields
     private final Date date;
     private final Content content;
@@ -28,9 +31,10 @@ public class Review {
     /**
      * Every field must be present and not null.
      */
-    public Review(Name name, Date date, Content content, Rating rating, Set<Tag> tags) {
+    public Review(Name name, Address address, Date date, Content content, Rating rating, Set<Tag> tags) {
         requireAllNonNull(name, date, content, tags);
         this.name = name;
+        this.address = address;
         this.date = date;
         this.content = content;
         this.rating = rating;
@@ -39,6 +43,10 @@ public class Review {
 
     public Name getName() {
         return name;
+    }
+
+    public Address getAddress() {
+        return address;
     }
 
     public Date getDate() {
@@ -92,24 +100,27 @@ public class Review {
             return false;
         }
 
-        Review otherStall = (Review) other;
-        return otherStall.getName().equals(getName())
-                && otherStall.getDate().equals(getDate())
-                && otherStall.getContent().equals(getContent())
-                && otherStall.getRating().equals(getRating())
-                && otherStall.getTags().equals(getTags());
+        Review otherReview = (Review) other;
+        return otherReview.getName().equals(getName())
+                && otherReview.getAddress().equals(getAddress())
+                && otherReview.getDate().equals(getDate())
+                && otherReview.getContent().equals(getContent())
+                && otherReview.getRating().equals(getRating())
+                && otherReview.getTags().equals(getTags());
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, date, content, rating, tags);
+        return Objects.hash(name, address, date, content, rating, tags);
     }
 
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
         builder.append(getName())
+                .append("; Address: ")
+                .append(getAddress())
                 .append("; Date: ")
                 .append(getDate())
                 .append("; Content: ")

--- a/src/main/java/foodwhere/model/review/ReviewBuilder.java
+++ b/src/main/java/foodwhere/model/review/ReviewBuilder.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import foodwhere.model.commons.Name;
 import foodwhere.model.commons.Tag;
+import foodwhere.model.stall.Address;
 import foodwhere.model.util.SampleDataUtil;
 
 /**
@@ -13,11 +14,13 @@ import foodwhere.model.util.SampleDataUtil;
 public class ReviewBuilder {
 
     public static final String DEFAULT_NAME = "Untitled Review";
+    public static final String DEFAULT_ADDRESS = "Unknown Location";
     public static final String DEFAULT_DATE = "1/1/1970";
     public static final String DEFAULT_CONTENT = "No comment.";
     public static final String DEFAULT_RATING = "3";
 
     private Name name;
+    private Address address;
     private Date date;
     private Content content;
     private Rating rating;
@@ -28,6 +31,7 @@ public class ReviewBuilder {
      */
     public ReviewBuilder() {
         name = new Name(DEFAULT_NAME);
+        address = new Address(DEFAULT_ADDRESS);
         date = new Date(DEFAULT_DATE);
         content = new Content(DEFAULT_CONTENT);
         rating = new Rating(DEFAULT_RATING);
@@ -38,7 +42,8 @@ public class ReviewBuilder {
      * Initializes the ReviewBuilder with the data of {@code reviewToCopy}.
      */
     public ReviewBuilder(Review reviewToCopy) {
-        name = new Name(reviewToCopy.getName().fullName);
+        name = reviewToCopy.getName();
+        address = reviewToCopy.getAddress();
         date = reviewToCopy.getDate();
         content = reviewToCopy.getContent();
         rating = reviewToCopy.getRating();
@@ -50,6 +55,14 @@ public class ReviewBuilder {
      */
     public ReviewBuilder withName(String name) {
         this.name = new Name(name);
+        return this;
+    }
+
+    /**
+     * Sets the {@code Address} of the {@code Review} that we are building.
+     */
+    public ReviewBuilder withAddress(String address) {
+        this.address = new Address(address);
         return this;
     }
 
@@ -86,7 +99,7 @@ public class ReviewBuilder {
     }
 
     public Review build() {
-        return new Review(name, date, content, rating, tags);
+        return new Review(name, address, date, content, rating, tags);
     }
 
 }

--- a/src/main/java/foodwhere/model/stall/Stall.java
+++ b/src/main/java/foodwhere/model/stall/Stall.java
@@ -82,7 +82,8 @@ public class Stall {
         }
 
         return otherStall != null
-                && otherStall.getName().equals(getName());
+                && otherStall.getName().equals(getName())
+                && otherStall.getAddress().equals(getAddress());
     }
 
     /**

--- a/src/main/java/foodwhere/model/util/SampleDataUtil.java
+++ b/src/main/java/foodwhere/model/util/SampleDataUtil.java
@@ -36,10 +36,12 @@ public class SampleDataUtil {
 
     public static Review[] getSampleReviews() {
         return new Review[] {
-            new Review(new Name("Alex Chicken Rice"), new Date("20/09/2022"),
-                    new Content("Very tasty. Worth the trip"), new Rating("5"), getTagSet("travelworthy")),
-            new Review(new Name("Irfan Muslim Food"), new Date("21/09/2022"),
-                    new Content("Very affordable"), new Rating("3"), getTagSet("halal"))
+            new Review(new Name("Alex Chicken Rice"), new Address("Blk 30 Geylang Street 29, #06-40"),
+                    new Date("20/09/2022"), new Content("Very tasty. Worth the trip"), new Rating("5"),
+                    getTagSet("travelworthy")),
+            new Review(new Name("Irfan Muslim Food"), new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
+                    new Date("21/09/2022"), new Content("Very affordable"), new Rating("3"),
+                    getTagSet("halal"))
         };
     }
 

--- a/src/main/java/foodwhere/storage/JsonAdaptedReview.java
+++ b/src/main/java/foodwhere/storage/JsonAdaptedReview.java
@@ -16,6 +16,7 @@ import foodwhere.model.review.Content;
 import foodwhere.model.review.Date;
 import foodwhere.model.review.Rating;
 import foodwhere.model.review.Review;
+import foodwhere.model.stall.Address;
 
 /**
  * Jackson-friendly version of {@link Review}.
@@ -62,10 +63,15 @@ class JsonAdaptedReview {
      *
      * @throws IllegalValueException if there were any data constraints violated in the adapted stall.
      */
-    public Review toModelType(Name modelName) throws IllegalValueException {
+    public Review toModelType(Name modelName, Address modelAddress) throws IllegalValueException {
         if (modelName == null) {
             throw new IllegalValueException(String.format(JsonAdaptedReview.MISSING_FIELD_MESSAGE_FORMAT,
                     Name.class.getSimpleName()));
+        }
+
+        if (modelAddress == null) {
+            throw new IllegalValueException(String.format(JsonAdaptedReview.MISSING_FIELD_MESSAGE_FORMAT,
+                    Address.class.getSimpleName()));
         }
 
         final List<Tag> reviewTags = new ArrayList<>();
@@ -102,7 +108,7 @@ class JsonAdaptedReview {
 
         final Set<Tag> modelTags = new HashSet<>(reviewTags);
 
-        return new Review(modelName, modelDate, modelContent, modelRating, modelTags);
+        return new Review(modelName, modelAddress, modelDate, modelContent, modelRating, modelTags);
     }
 
 }

--- a/src/main/java/foodwhere/storage/JsonAdaptedStall.java
+++ b/src/main/java/foodwhere/storage/JsonAdaptedStall.java
@@ -126,9 +126,10 @@ class JsonAdaptedStall {
             throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS);
         }
         final Name modelStallName = new Name(name);
+        final Address modelStallAddress = new Address(address);
 
         for (JsonAdaptedReview review : reviews) {
-            modelReviews.add(review.toModelType(modelStallName));
+            modelReviews.add(review.toModelType(modelStallName, modelStallAddress));
         }
         return modelReviews;
     }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicateStallAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicateStallAddressBook.json
@@ -5,6 +5,6 @@
     "tags": [ "friends" ]
   }, {
     "name": "Alice Pauline",
-    "address": "4th street"
+    "address": "123, Jurong West Ave 6, #08-111"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalStallsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalStallsAddressBook.json
@@ -6,7 +6,7 @@
     "tags" : [ "friends" ],
     "reviews" : [ {
       "date" : "1/1/2020",
-      "content" : "123, Jurong West Ave 6, #08-111",
+      "content" : "Great view and decor!",
       "rating": 3,
       "tags" : [ "friends" ]
     } ]
@@ -16,7 +16,7 @@
     "tags" : [ "owesMoney", "friends" ],
     "reviews" : [ {
       "date" : "31/12/2021",
-      "content" : "311, Clementi Ave 2, #02-25",
+      "content" : "The food is warm and nourishing.",
       "rating": 3,
       "tags" : [ "owesMoney", "friends" ]
     } ]

--- a/src/test/java/foodwhere/logic/commands/RAddCommandTest.java
+++ b/src/test/java/foodwhere/logic/commands/RAddCommandTest.java
@@ -30,8 +30,10 @@ public class RAddCommandTest {
         Index indexLastStall = Index.fromOneBased(model.getFilteredStallList().size());
         Stall lastStall = model.getFilteredStallList().get(indexLastStall.getZeroBased());
         String name = lastStall.getName().toString();
+        String address = lastStall.getAddress().toString();
 
-        Review review = new ReviewBuilder().withName(name).withTags(CommandTestUtil.VALID_TAG_FRIEND).build();
+        Review review = new ReviewBuilder().withName(name)
+                .withAddress(address).withTags(CommandTestUtil.VALID_TAG_FRIEND).build();
         RAddCommand rAddCommand = new RAddCommand(indexLastStall, review.getDate(),
                 review.getContent(), review.getRating(), review.getTags());
         String expectedMessage = String.format(RAddCommand.MESSAGE_SUCCESS, review);
@@ -47,8 +49,9 @@ public class RAddCommandTest {
         Index indexLastStall = Index.fromOneBased(model.getFilteredStallList().size());
         Stall lastStall = model.getFilteredStallList().get(indexLastStall.getZeroBased());
         String name = lastStall.getName().toString();
+        String address = lastStall.getAddress().toString();
 
-        Review review = new ReviewBuilder().withName(name).build();
+        Review review = new ReviewBuilder().withName(name).withAddress(address).build();
         RAddCommand rAddCommand = new RAddCommand(indexLastStall, review.getDate(),
                 review.getContent(), review.getRating(), review.getTags());
         String expectedMessage = String.format(RAddCommand.MESSAGE_SUCCESS, review);
@@ -67,8 +70,9 @@ public class RAddCommandTest {
         Stall stallInFilteredList =
                 model.getFilteredStallList().get(TypicalIndexes.INDEX_FIRST_STALL.getZeroBased());
         String name = stallInFilteredList.getName().toString();
+        String address = stallInFilteredList.getAddress().toString();
 
-        Review review = new ReviewBuilder().withName(name).build();
+        Review review = new ReviewBuilder().withName(name).withAddress(address).build();
 
         RAddCommand rAddCommand = new RAddCommand(TypicalIndexes.INDEX_FIRST_STALL, review.getDate(),
                 review.getContent(), review.getRating(), review.getTags());

--- a/src/test/java/foodwhere/logic/commands/SAddCommandTest.java
+++ b/src/test/java/foodwhere/logic/commands/SAddCommandTest.java
@@ -121,6 +121,11 @@ public class SAddCommandTest {
         }
 
         @Override
+        public void addReviewToStall(Review review, Stall stall) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setReview(Review target, Review editedReview) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/foodwhere/model/AddressBookTest.java
+++ b/src/test/java/foodwhere/model/AddressBookTest.java
@@ -1,6 +1,5 @@
 package foodwhere.model;
 
-import static foodwhere.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static foodwhere.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static foodwhere.testutil.Assert.assertThrows;
 import static foodwhere.testutil.TypicalStalls.ALICE;
@@ -49,7 +48,7 @@ public class AddressBookTest {
     @Test
     public void resetData_withDuplicateStalls_throwsDuplicateStallException() {
         // Two stalls with the same identity fields
-        Stall editedAlice = new StallBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
+        Stall editedAlice = new StallBuilder(ALICE).withTags(VALID_TAG_HUSBAND)
                 .build();
         List<Stall> newStalls = Arrays.asList(ALICE, editedAlice);
         AddressBookStub newData = new AddressBookStub(newStalls);
@@ -76,7 +75,7 @@ public class AddressBookTest {
     @Test
     public void hasStall_stallWithSameIdentityFieldsInAddressBook_returnsTrue() {
         addressBook.addStall(ALICE);
-        Stall editedAlice = new StallBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
+        Stall editedAlice = new StallBuilder(ALICE).withTags(VALID_TAG_HUSBAND)
                 .build();
         assertTrue(addressBook.hasStall(editedAlice));
     }

--- a/src/test/java/foodwhere/model/stall/StallTest.java
+++ b/src/test/java/foodwhere/model/stall/StallTest.java
@@ -26,9 +26,24 @@ public class StallTest {
         // null -> returns false
         assertFalse(TypicalStalls.ALICE.isSameStall(null));
 
-        // same name, all other attributes different -> returns true
+        // same name, all other attributes different -> returns false
         Stall editedAlice = new StallBuilder(TypicalStalls.ALICE)
                 .withAddress(CommandTestUtil.VALID_ADDRESS_BOB)
+                .withTags(CommandTestUtil.VALID_TAG_HUSBAND)
+                .withReviews(TypicalReviews.BOB)
+                .build();
+        assertFalse(TypicalStalls.ALICE.isSameStall(editedAlice));
+
+        // same address, all other attributes different -> returns false
+        editedAlice = new StallBuilder(TypicalStalls.ALICE)
+                .withName(CommandTestUtil.VALID_NAME_BOB)
+                .withTags(CommandTestUtil.VALID_TAG_HUSBAND)
+                .withReviews(TypicalReviews.BOB)
+                .build();
+        assertFalse(TypicalStalls.ALICE.isSameStall(editedAlice));
+
+        // same address and name, all other attributes different -> returns true
+        editedAlice = new StallBuilder(TypicalStalls.ALICE)
                 .withTags(CommandTestUtil.VALID_TAG_HUSBAND)
                 .withReviews(TypicalReviews.BOB)
                 .build();

--- a/src/test/java/foodwhere/model/stall/UniqueStallListTest.java
+++ b/src/test/java/foodwhere/model/stall/UniqueStallListTest.java
@@ -41,7 +41,6 @@ public class UniqueStallListTest {
         uniqueStallList.add(TypicalStalls.ALICE);
         Stall editedAlice =
                 new StallBuilder(TypicalStalls.ALICE)
-                        .withAddress(CommandTestUtil.VALID_ADDRESS_BOB)
                         .withTags(CommandTestUtil.VALID_TAG_HUSBAND)
                 .build();
         assertTrue(uniqueStallList.contains(editedAlice));

--- a/src/test/java/foodwhere/storage/JsonAdaptedReviewTest.java
+++ b/src/test/java/foodwhere/storage/JsonAdaptedReviewTest.java
@@ -12,14 +12,17 @@ import org.junit.jupiter.api.Test;
 
 import foodwhere.commons.exceptions.IllegalValueException;
 import foodwhere.model.commons.Name;
+import foodwhere.model.commons.Tag;
 import foodwhere.model.review.Content;
 import foodwhere.model.review.Date;
 import foodwhere.model.review.Rating;
+import foodwhere.model.stall.Address;
 
 public class JsonAdaptedReviewTest {
     private static final String INVALID_TAG = "#friend";
 
     private static final Name VALID_NAME = new Name(BENSON.getName().fullName);
+    private static final Address VALID_ADDRESS = new Address(BENSON.getAddress().value);
     private static final String VALID_DATE = "1/1/2000";
     private static final String INVALID_DATE = "1/1/1";
     private static final String VALID_CONTENT = BENSON.getContent().toString();
@@ -32,7 +35,7 @@ public class JsonAdaptedReviewTest {
     @Test
     public void toModelType_validReviewTags_returnsReview() throws Exception {
         JsonAdaptedReview review = new JsonAdaptedReview(BENSON);
-        assertEquals(BENSON, review.toModelType(VALID_NAME));
+        assertEquals(BENSON, review.toModelType(VALID_NAME, VALID_ADDRESS));
     }
 
     @Test
@@ -40,7 +43,17 @@ public class JsonAdaptedReviewTest {
         JsonAdaptedReview review = new JsonAdaptedReview(VALID_DATE, VALID_CONTENT, VALID_RATING, new ArrayList<>());
         String expectedMessage =
                 String.format(JsonAdaptedReview.MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, () -> review.toModelType(null));
+        assertThrows(IllegalValueException.class, expectedMessage, () ->
+                review.toModelType(null, VALID_ADDRESS));
+    }
+
+    @Test
+    public void toModelType_nullAddress_throwsIllegalValueException() {
+        JsonAdaptedReview review = new JsonAdaptedReview(VALID_DATE, VALID_CONTENT, VALID_RATING, new ArrayList<>());
+        String expectedMessage =
+                String.format(JsonAdaptedReview.MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, () ->
+                review.toModelType(VALID_NAME, null));
     }
 
     @Test
@@ -48,16 +61,19 @@ public class JsonAdaptedReviewTest {
         JsonAdaptedReview review = new JsonAdaptedReview(VALID_DATE, VALID_CONTENT, null, new ArrayList<>());
         String expectedMessage =
                 String.format(JsonAdaptedReview.MISSING_FIELD_MESSAGE_FORMAT, Rating.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, () -> review.toModelType(VALID_NAME));
+        assertThrows(IllegalValueException.class, expectedMessage, () ->
+                review.toModelType(VALID_NAME, VALID_ADDRESS));
     }
 
     @Test
     public void toModelType_invalidRating_throwsIllegalValueException() {
         JsonAdaptedReview review = new JsonAdaptedReview(VALID_DATE, VALID_CONTENT, -1, new ArrayList<>());
         String expectedMessage = Rating.MESSAGE_CONSTRAINTS;
-        assertThrows(IllegalValueException.class, expectedMessage, () -> review.toModelType(VALID_NAME));
+        assertThrows(IllegalValueException.class, expectedMessage, () ->
+                review.toModelType(VALID_NAME, VALID_ADDRESS));
         JsonAdaptedReview review2 = new JsonAdaptedReview(VALID_DATE, VALID_CONTENT, 6, new ArrayList<>());
-        assertThrows(IllegalValueException.class, expectedMessage, () -> review2.toModelType(VALID_NAME));
+        assertThrows(IllegalValueException.class, expectedMessage, () ->
+                review2.toModelType(VALID_NAME, VALID_ADDRESS));
     }
 
     @Test
@@ -65,14 +81,16 @@ public class JsonAdaptedReviewTest {
         JsonAdaptedReview review = new JsonAdaptedReview(VALID_DATE, null, VALID_RATING, new ArrayList<>());
         String expectedMessage =
                 String.format(JsonAdaptedReview.MISSING_FIELD_MESSAGE_FORMAT, Content.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, () -> review.toModelType(VALID_NAME));
+        assertThrows(IllegalValueException.class, expectedMessage, () ->
+                review.toModelType(VALID_NAME, VALID_ADDRESS));
     }
 
     @Test
     public void toModelType_invalidContent_throwsIllegalValueException() {
         JsonAdaptedReview review = new JsonAdaptedReview(VALID_DATE, INVALID_CONTENT, VALID_RATING, new ArrayList<>());
         String expectedMessage = Content.MESSAGE_CONSTRAINTS;
-        assertThrows(IllegalValueException.class, expectedMessage, () -> review.toModelType(VALID_NAME));
+        assertThrows(IllegalValueException.class, expectedMessage, () ->
+                review.toModelType(VALID_NAME, VALID_ADDRESS));
     }
 
     @Test
@@ -80,14 +98,16 @@ public class JsonAdaptedReviewTest {
         JsonAdaptedReview review = new JsonAdaptedReview(null, VALID_CONTENT, VALID_RATING, new ArrayList<>());
         String expectedMessage =
                 String.format(JsonAdaptedReview.MISSING_FIELD_MESSAGE_FORMAT, Date.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, () -> review.toModelType(VALID_NAME));
+        assertThrows(IllegalValueException.class, expectedMessage, () ->
+                review.toModelType(VALID_NAME, VALID_ADDRESS));
     }
 
     @Test
     public void toModelType_invalidDate_throwsIllegalValueException() {
         JsonAdaptedReview review = new JsonAdaptedReview(INVALID_DATE, VALID_CONTENT, VALID_RATING, new ArrayList<>());
         String expectedMessage = Date.MESSAGE_CONSTRAINTS;
-        assertThrows(IllegalValueException.class, expectedMessage, () -> review.toModelType(VALID_NAME));
+        assertThrows(IllegalValueException.class, expectedMessage, () ->
+                review.toModelType(VALID_NAME, VALID_ADDRESS));
     }
 
     @Test
@@ -96,7 +116,9 @@ public class JsonAdaptedReviewTest {
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedReview review = new JsonAdaptedReview(VALID_DATE, VALID_CONTENT, VALID_RATING,
                 invalidTags);
-        assertThrows(IllegalValueException.class, () -> review.toModelType(null));
+        String expectedMessage = Tag.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, () ->
+                review.toModelType(VALID_NAME, VALID_ADDRESS));
     }
 
 }

--- a/src/test/java/foodwhere/testutil/TypicalReviews.java
+++ b/src/test/java/foodwhere/testutil/TypicalReviews.java
@@ -1,5 +1,7 @@
 package foodwhere.testutil;
 
+import static foodwhere.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
+import static foodwhere.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static foodwhere.logic.commands.CommandTestUtil.VALID_CONTENT_AMY;
 import static foodwhere.logic.commands.CommandTestUtil.VALID_CONTENT_BOB;
 import static foodwhere.logic.commands.CommandTestUtil.VALID_DATE_AMY;
@@ -22,37 +24,48 @@ import foodwhere.model.review.ReviewBuilder;
 public class TypicalReviews {
 
     public static final Review ALICE = new ReviewBuilder().withName("Alice Pauline")
+            .withAddress("123, Jurong West Ave 6, #08-111")
             .withDate("01/01/2020")
-            .withContent("123, Jurong West Ave 6, #08-111")
+            .withContent("Great view and decor!")
             .withRating(3)
             .withTags("friends").build();
     public static final Review BENSON = new ReviewBuilder().withName("Benson Meier")
+            .withAddress("311, Clementi Ave 2, #02-25")
             .withDate("31/12/2021")
-            .withContent("311, Clementi Ave 2, #02-25")
+            .withContent("The food is warm and nourishing.")
             .withRating(3)
             .withTags("owesMoney", "friends").build();
     public static final Review CARL = new ReviewBuilder().withName("Carl Kurz")
+            .withAddress("wall street")
             .withDate("01/04/2020").withRating(3).withContent("wall street").build();
     public static final Review DANIEL = new ReviewBuilder().withName("Daniel Meier")
+            .withAddress("10th street")
             .withDate("29/02/2020").withRating(3).withContent("10th street").withTags("friends").build();
     public static final Review ELLE = new ReviewBuilder().withName("Elle Meyer")
+            .withAddress("michegan ave")
             .withDate("29/09/2003").withRating(3).withContent("michegan ave").build();
     public static final Review FIONA = new ReviewBuilder().withName("Fiona Kunz")
+            .withAddress("little tokyo")
             .withDate("06/06/2007").withRating(3).withContent("little tokyo").build();
     public static final Review GEORGE = new ReviewBuilder().withName("George Best")
+            .withAddress("4th street")
             .withDate("20/07/2017").withRating(3).withContent("4th street").build();
 
     // Manually added
     public static final Review HOON = new ReviewBuilder().withName("Hoon Meier")
+            .withAddress("little india")
             .withDate("25/12/2020").withRating(3).withContent("little india").build();
     public static final Review IDA = new ReviewBuilder().withName("Ida Mueller")
+            .withAddress("chicago ave")
             .withDate("09/09/2022").withRating(3).withContent("chicago ave").build();
 
     // Manually added - Review's details found in {@code CommandTestUtil}
     public static final Review AMY = new ReviewBuilder().withName(VALID_NAME_AMY)
+            .withAddress(VALID_ADDRESS_AMY)
             .withDate(VALID_DATE_AMY).withContent(VALID_CONTENT_AMY)
             .withTags(VALID_TAG_FRIEND).build();
     public static final Review BOB = new ReviewBuilder().withName(VALID_NAME_BOB)
+            .withAddress(VALID_ADDRESS_BOB)
             .withDate(VALID_DATE_BOB).withContent(VALID_CONTENT_BOB)
             .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
 


### PR DESCRIPTION
This resolves #118.

The new notion of equality involves Name and Address.

The edits involve:
1. Adding Address to Review

Further edits we can do:
1. Reviews in the UI do not clearly specify which stall they belong to. Therefore, I think we can print the address or index of the stall in the UI if there is a name collision so that it is easier to use.
1. Move Address into model.commons