### PR TITLE
Fix sedit/redit command with t/ repeated fails to run

### DIFF
--- a/src/main/java/foodwhere/logic/parser/ParserUtil.java
+++ b/src/main/java/foodwhere/logic/parser/ParserUtil.java
@@ -1,5 +1,6 @@
 package foodwhere.logic.parser;
 
+import static java.util.Objects.isNull;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
@@ -74,7 +75,10 @@ public class ParserUtil {
         String[] tags = input.split(" ");
         final Set<Tag> tagSet = new HashSet<>();
         for (String tag : tags) {
-            tagSet.add(parseTag(tag));
+            Tag parsedTag = parseTag(tag);
+            if (!isNull(parsedTag)) {
+                tagSet.add(parsedTag);
+            }
         }
         return tagSet;
     }
@@ -103,6 +107,9 @@ public class ParserUtil {
     public static Tag parseTag(String tag) throws ParseException {
         requireNonNull(tag);
         String trimmedTag = tag.trim();
+        if (trimmedTag.isEmpty()) {
+            return null;
+        }
         if (!Tag.isValidTag(trimmedTag)) {
             throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
         }
@@ -116,7 +123,10 @@ public class ParserUtil {
         requireNonNull(tags);
         final Set<Tag> tagSet = new HashSet<>();
         for (String tag : tags) {
-            tagSet.add(parseTag(tag));
+            Tag parsedTag = parseTag(tag);
+            if (!isNull(parsedTag)) {
+                tagSet.add(parsedTag);
+            }
         }
         return tagSet;
     }

--- a/src/main/java/foodwhere/model/commons/Tag.java
+++ b/src/main/java/foodwhere/model/commons/Tag.java
@@ -11,7 +11,7 @@ import static java.util.Objects.requireNonNull;
 public class Tag {
 
     public static final String MESSAGE_CONSTRAINTS = "Tags should be alphanumeric";
-    public static final String VALIDATION_REGEX = "^[a-zA-Z0-9]*$";
+    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
     public final String tag;
 

--- a/src/main/java/foodwhere/model/commons/Tag.java
+++ b/src/main/java/foodwhere/model/commons/Tag.java
@@ -11,7 +11,7 @@ import static java.util.Objects.requireNonNull;
 public class Tag {
 
     public static final String MESSAGE_CONSTRAINTS = "Tags should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String VALIDATION_REGEX = "^[a-zA-Z0-9]*$";
 
     public final String tag;
 

--- a/src/test/java/foodwhere/logic/parser/SEditCommandParserTest.java
+++ b/src/test/java/foodwhere/logic/parser/SEditCommandParserTest.java
@@ -73,11 +73,11 @@ public class SEditCommandParserTest {
 
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Stall} being edited,
         // parsing it together with a valid tag results in error
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY,
+        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + INVALID_TAG_DESC,
                 Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND,
+        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + INVALID_TAG_DESC + TAG_DESC_HUSBAND,
                 Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND,
+        assertParseFailure(parser, "1" + INVALID_TAG_DESC + TAG_DESC_FRIEND + TAG_DESC_HUSBAND,
                 Tag.MESSAGE_CONSTRAINTS);
 
         // multiple invalid values, but only the first invalid value is captured


### PR DESCRIPTION
Resolve #243 
PR/Issue to be discussed in the meeting. Do not merge.

Fixes issue by allowing blank strings to be allowed in Tag

However, this will allow empty tags to be created.

**Edit**
Instead of allowing empty strings in creation of Tag object, do not create Tag object if tag string is empty